### PR TITLE
Add option to de-select decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # bristlemouth-explorer
 Dev tools and playground for the Bristlemouth  open source standard
 
-# Adding a New Decoder
+## Adding a New Decoder
 New decoders can easily be added to the app by submitting a pull request in this repository, following these steps:
 1. Create a new file under `src/decoders` and export the new decoder. Ensure that your decoder implements the `Decoder` interface. You can refer to `src/decoders/default.ts` as an example
 2. Import and append the new decoder to the `decoders` variable at the end of `src/helpers/decoder.ts` file
 
 Once your pull request is merged, your new decoder will become accessible in the drop-down list, just like the existing ones!
+
+## License
+
+  bristlemouth-explorer is [MIT licensed](LICENSE).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "pre-commit": "lint-staged && pretty-quick --staged"
     }
   },
-  "license": "iMIT",
+  "license": "MIT",
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "pre-commit": "lint-staged && pretty-quick --staged"
     }
   },
+  "license": "iMIT",
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/src/decoders/default.ts
+++ b/src/decoders/default.ts
@@ -15,7 +15,7 @@ const defaultSensorStruct: SensorStruct = [
 ];
 
 export const defaultDecoder: Decoder = {
-  name: 'NewName (default)',
+  name: 'Toolkit Example (default)',
   config: [
     { name: 'temp', struct: defaultSensorStruct },
     { name: 'hum', struct: defaultSensorStruct },

--- a/src/decoders/default.ts
+++ b/src/decoders/default.ts
@@ -15,7 +15,7 @@ const defaultSensorStruct: SensorStruct = [
 ];
 
 export const defaultDecoder: Decoder = {
-  name: 'Toolkit Example (default)',
+  name: 'Toolkit example (default)',
   config: [
     { name: 'temp', struct: defaultSensorStruct },
     { name: 'hum', struct: defaultSensorStruct },

--- a/src/decoders/default.ts
+++ b/src/decoders/default.ts
@@ -15,7 +15,7 @@ const defaultSensorStruct: SensorStruct = [
 ];
 
 export const defaultDecoder: Decoder = {
-  name: 'default',
+  name: 'NewName (default)',
   config: [
     { name: 'temp', struct: defaultSensorStruct },
     { name: 'hum', struct: defaultSensorStruct },

--- a/src/routes/Sensors/DataTable/__snapshots__/index.test.tsx.snap
+++ b/src/routes/Sensors/DataTable/__snapshots__/index.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`renders as expected 1`] = `
       </div>
       <div
         class="MuiTableContainer-root css-rorn0c-MuiTableContainer-root"
+        style="overflow: hidden;"
       >
         <table
           class="MuiTable-root MuiTable-stickyHeader css-xn82ks-MuiTable-root"
@@ -68,10 +69,16 @@ exports[`renders as expected 1`] = `
                 PDT
               </th>
               <th
-                class="MuiTableCell-root MuiTableCell-head MuiTableCell-stickyHeader MuiTableCell-alignLeft MuiTableCell-sizeSmall css-1hrvygi-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-stickyHeader MuiTableCell-sizeSmall css-1hrvygi-MuiTableCell-root"
                 scope="col"
               >
                 Node ID
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-stickyHeader MuiTableCell-sizeSmall css-1hrvygi-MuiTableCell-root"
+                scope="col"
+              >
+                Raw data
               </th>
             </tr>
           </thead>
@@ -118,12 +125,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c00ec2f8b3edcea4c3f3c0059ab033ee3152c3f3c005bd31c3ed591c93f3c00fd22c842cffb0e3e3c003a4d1743aaaf4c3d3c00bf581b430e17663d3c00d3036c3ea890f33b3c0098a7da4178953e3d3c00f241773f4403003f3c0041a718436883d642
                 </p>
               </td>
             </tr>
@@ -176,12 +192,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c0033c4813eb9533b3f3c008d4d18beb7b1433f3c004ba35cbd436ca63f3c00e13ac8426baeae3d3c004b3e17433a4f583d3c009a591b43ab7e663d3c00756e6d3e14bfd63b3c00c1cadb4123e90e3d3c00fa597f3f2249eb3e3c00148e1f4322c6c042
                 </p>
               </td>
             </tr>
@@ -234,12 +259,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c001ae5063d7dfc343f3c00eabaddbb0810403f3c00edc3473e9905ad3f3c003016c842aa9ae73d3c00852b1743070d4a3d3c00075a1b43f939723d3c0050d76d3e453bcf3b3c0044c4dc419f611c3d3c0017b7693f24a7f53e3c00220231433d59d642
                 </p>
               </td>
             </tr>
@@ -292,12 +326,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c00304ca63d9189373f3c00968d613de74d423f3c0026bf883ec4589b3f3c00f20bc8429a74123e3c0052181743a574713d3c00bf581b430cf0713d3c00acf76e3e251fe43b3c00fde2dd413b951a3d3c00e02d703f02b7ef3e3c00ab8a25432631db42
                 </p>
               </td>
             </tr>
@@ -350,12 +393,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c00986e723ead44373f3c00e78ca8bdfc9e4b3f3c006154523d2def983f3c00e557c8426c51133e3c00820e17436fa0ca3d3c00bc5b1b437956573d3c00d08e6e3ee44deb3b3c00d9cede41783c0a3d3c00f594773fe59c053f3c00711d214360aec042
                 </p>
               </td>
             </tr>
@@ -408,12 +460,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3d00ca5b423eb79e303f3d002b0e0a3dde744c3f3d00ba8afc3d9be08d3f3d00012fc842eef90f3e3d0039fc164321297f3d3d003b5a1b43dbaa833d3d00dfd16d3e7931ec3b3d00a6cedf41b992243d3d00dff26e3ff369073f3d00125b30434c93d242
                 </p>
               </td>
             </tr>
@@ -466,12 +527,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c00a7323f3e28a9433f3c000e74daba5ef1373f3c008cb94b3eee07a93f3c00c92fc84207bd0b3e3c00d0e916430cf0713d3c00295c1b4382d3623d3c005d236f3eeca7ca3b3c003d0ae141c591413d3c00f3d56b3fde02093f3c0007ba1d43482ed342
                 </p>
               </td>
             </tr>
@@ -524,12 +594,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c00dfbb403e09f8373f3c0089f7c93d372b503f3c00dfbb603ea542a03f3c006a03c842e5b0023e3c0074da164301459c3d3c00965c1b439925473d3c007ed66f3e69ccd63b3c00c14ae241acd8363d3c009d36803f0ec7ef3e3c005c0f1943bb39d142
                 </p>
               </td>
             </tr>
@@ -582,12 +661,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3c00f1cf1f3ef5643e3f3c00141adbbd3bf9393f3c003686833e8cd3b53f3c008c25c8423fae203e3c00b1c41643f939723d3c00745a1b430cf0713d3c003bdf6f3e6ba7d33b3c003c98e341b87f533d3c00a28f743f1128e73e3c000e5424439823c742
                 </p>
               </td>
             </tr>
@@ -640,12 +728,21 @@ exports[`renders as expected 1`] = `
                 </p>
               </th>
               <td
-                class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                 >
                   0xadef442a8e274b78
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                >
+                  3e00f5375b3e4654473f3e00390c0dbdc705363f3e0064a9d43d5db8ab3f3e00d56dc842258a003e3e00a8ae16436245873d3e0030591b43f64c833d3e00be2a733e25c4d33b3e00121de54140476d3d3e00adb5763f5678f53e3e0082631243bf73b942
                 </p>
               </td>
             </tr>

--- a/src/routes/Sensors/DataTable/index.tsx
+++ b/src/routes/Sensors/DataTable/index.tsx
@@ -79,11 +79,24 @@ function Row({ data, extraColumns }: RowProps) {
         <TableCell component="th" scope="row">
           <Typography whiteSpace="nowrap">{data.timestamp}</Typography>
         </TableCell>
-        <TableCell align="left">
+        <TableCell>
           <Typography>{data.nodeId}</Typography>
         </TableCell>
+        {extraColumns === undefined && (
+          <TableCell>
+            <Typography
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+              overflow="hidden"
+              marginLeft="auto"
+              maxWidth={`calc(100vw - 59rem)`}
+            >
+              {data.encodedData}
+            </Typography>
+          </TableCell>
+        )}
         {extraColumns?.map((x) => (
-          <TableCell align="left" key={`${x.sensor}_${x.key}`}>
+          <TableCell key={`${x.sensor}_${x.key}`}>
             <Typography>
               {data.decodedData && data.decodedData[x.sensor][x.key].toFixed(2)}
             </Typography>
@@ -280,7 +293,7 @@ function DataTable() {
           </RoundedButton>
         </Stack>
 
-        <TableContainer>
+        <TableContainer style={{ overflow: 'hidden' }}>
           <Table size="small" stickyHeader>
             <StyledTableHead>
               <TableRow>
@@ -291,11 +304,13 @@ function DataTable() {
                     ? 'UTC'
                     : DateTime.now().offsetNameShort}
                 </HeaderTableCell>
-                <HeaderTableCell align="left">Node ID</HeaderTableCell>
+                <HeaderTableCell>Node ID</HeaderTableCell>
+                {extraColumns === undefined && (
+                  <HeaderTableCell>Raw data</HeaderTableCell>
+                )}
                 {extraColumns?.map((x) => (
                   <HeaderTableCell
                     key={`${x.sensor}_${x.key}`}
-                    align="left"
                   >{`${x.sensor}_${x.key}`}</HeaderTableCell>
                 ))}
               </TableRow>

--- a/src/routes/Sensors/SensorSelector/index.tsx
+++ b/src/routes/Sensors/SensorSelector/index.tsx
@@ -216,7 +216,7 @@ function SensorSelector() {
                     );
                   }}
                 >
-                  <MenuItem value="">&nbsp;</MenuItem>
+                  <MenuItem value="">All nodes</MenuItem>
                   {availableNodeIds.map((x) => (
                     <MenuItem key={x} value={x}>
                       {x}
@@ -242,7 +242,7 @@ function SensorSelector() {
                       );
                     }}
                   >
-                    <MenuItem value="">no decoder</MenuItem>
+                    <MenuItem value="">Unselect decoder</MenuItem>
                     {decoderOptions.map((x) => (
                       <MenuItem key={x.name} value={x.name}>
                         {x.name}

--- a/src/routes/Sensors/SensorSelector/index.tsx
+++ b/src/routes/Sensors/SensorSelector/index.tsx
@@ -242,6 +242,7 @@ function SensorSelector() {
                       );
                     }}
                   >
+                    <MenuItem value="">&nbsp;</MenuItem>
                     {decoderOptions.map((x) => (
                       <MenuItem key={x.name} value={x.name}>
                         {x.name}

--- a/src/routes/Sensors/SensorSelector/index.tsx
+++ b/src/routes/Sensors/SensorSelector/index.tsx
@@ -242,7 +242,7 @@ function SensorSelector() {
                       );
                     }}
                   >
-                    <MenuItem value="">&nbsp;</MenuItem>
+                    <MenuItem value="">no decoder</MenuItem>
                     {decoderOptions.map((x) => (
                       <MenuItem key={x.name} value={x.name}>
                         {x.name}

--- a/src/routes/Sensors/__snapshots__/index.test.tsx.snap
+++ b/src/routes/Sensors/__snapshots__/index.test.tsx.snap
@@ -555,6 +555,7 @@ exports[`renders as expected 1`] = `
           </div>
           <div
             class="MuiTableContainer-root css-rorn0c-MuiTableContainer-root"
+            style="overflow: hidden;"
           >
             <table
               class="MuiTable-root MuiTable-stickyHeader css-xn82ks-MuiTable-root"
@@ -579,10 +580,16 @@ exports[`renders as expected 1`] = `
                     PDT
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-stickyHeader MuiTableCell-alignLeft MuiTableCell-sizeSmall css-1hrvygi-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-stickyHeader MuiTableCell-sizeSmall css-1hrvygi-MuiTableCell-root"
                     scope="col"
                   >
                     Node ID
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-stickyHeader MuiTableCell-sizeSmall css-1hrvygi-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Raw data
                   </th>
                 </tr>
               </thead>
@@ -629,12 +636,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c00ec2f8b3edcea4c3f3c0059ab033ee3152c3f3c005bd31c3ed591c93f3c00fd22c842cffb0e3e3c003a4d1743aaaf4c3d3c00bf581b430e17663d3c00d3036c3ea890f33b3c0098a7da4178953e3d3c00f241773f4403003f3c0041a718436883d642
                     </p>
                   </td>
                 </tr>
@@ -687,12 +703,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c0033c4813eb9533b3f3c008d4d18beb7b1433f3c004ba35cbd436ca63f3c00e13ac8426baeae3d3c004b3e17433a4f583d3c009a591b43ab7e663d3c00756e6d3e14bfd63b3c00c1cadb4123e90e3d3c00fa597f3f2249eb3e3c00148e1f4322c6c042
                     </p>
                   </td>
                 </tr>
@@ -745,12 +770,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c001ae5063d7dfc343f3c00eabaddbb0810403f3c00edc3473e9905ad3f3c003016c842aa9ae73d3c00852b1743070d4a3d3c00075a1b43f939723d3c0050d76d3e453bcf3b3c0044c4dc419f611c3d3c0017b7693f24a7f53e3c00220231433d59d642
                     </p>
                   </td>
                 </tr>
@@ -803,12 +837,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c00304ca63d9189373f3c00968d613de74d423f3c0026bf883ec4589b3f3c00f20bc8429a74123e3c0052181743a574713d3c00bf581b430cf0713d3c00acf76e3e251fe43b3c00fde2dd413b951a3d3c00e02d703f02b7ef3e3c00ab8a25432631db42
                     </p>
                   </td>
                 </tr>
@@ -861,12 +904,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c00986e723ead44373f3c00e78ca8bdfc9e4b3f3c006154523d2def983f3c00e557c8426c51133e3c00820e17436fa0ca3d3c00bc5b1b437956573d3c00d08e6e3ee44deb3b3c00d9cede41783c0a3d3c00f594773fe59c053f3c00711d214360aec042
                     </p>
                   </td>
                 </tr>
@@ -919,12 +971,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3d00ca5b423eb79e303f3d002b0e0a3dde744c3f3d00ba8afc3d9be08d3f3d00012fc842eef90f3e3d0039fc164321297f3d3d003b5a1b43dbaa833d3d00dfd16d3e7931ec3b3d00a6cedf41b992243d3d00dff26e3ff369073f3d00125b30434c93d242
                     </p>
                   </td>
                 </tr>
@@ -977,12 +1038,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c00a7323f3e28a9433f3c000e74daba5ef1373f3c008cb94b3eee07a93f3c00c92fc84207bd0b3e3c00d0e916430cf0713d3c00295c1b4382d3623d3c005d236f3eeca7ca3b3c003d0ae141c591413d3c00f3d56b3fde02093f3c0007ba1d43482ed342
                     </p>
                   </td>
                 </tr>
@@ -1035,12 +1105,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c00dfbb403e09f8373f3c0089f7c93d372b503f3c00dfbb603ea542a03f3c006a03c842e5b0023e3c0074da164301459c3d3c00965c1b439925473d3c007ed66f3e69ccd63b3c00c14ae241acd8363d3c009d36803f0ec7ef3e3c005c0f1943bb39d142
                     </p>
                   </td>
                 </tr>
@@ -1093,12 +1172,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3c00f1cf1f3ef5643e3f3c00141adbbd3bf9393f3c003686833e8cd3b53f3c008c25c8423fae203e3c00b1c41643f939723d3c00745a1b430cf0713d3c003bdf6f3e6ba7d33b3c003c98e341b87f533d3c00a28f743f1128e73e3c000e5424439823c742
                     </p>
                   </td>
                 </tr>
@@ -1151,12 +1239,21 @@ exports[`renders as expected 1`] = `
                     </p>
                   </th>
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     >
                       0xadef442a8e274b78
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-dsuxgy-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-yohos5-MuiTypography-root"
+                    >
+                      3e00f5375b3e4654473f3e00390c0dbdc705363f3e0064a9d43d5db8ab3f3e00d56dc842258a003e3e00a8ae16436245873d3e0030591b43f64c833d3e00be2a733e25c4d33b3e00121de54140476d3d3e00adb5763f5678f53e3e0082631243bf73b942
                     </p>
                   </td>
                 </tr>


### PR DESCRIPTION
Adds the 'empty' decoder option, which, when selected, displays the raw value in the table, without decoding the data.

Also add the "license" field to `package.json`

resolves https://github.com/aqualinkorg/bristlemouth-explorer/issues/7