### PR TITLE
Update landing page and add details

### DIFF
--- a/src/common/Footer/__snapshots__/index.test.tsx.snap
+++ b/src/common/Footer/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders as expected 1`] = `
         </a>
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-o4qrxl-MuiTypography-root-MuiLink-root"
-          href="https://www.bristlemouth.org/"
+          href="https://www.bristlemouth.org/pioneer"
           rel="noopener noreferrer"
           style="margin-left: 2rem; font-weight: bold; text-align: center;"
           target="_blank"

--- a/src/common/Footer/__snapshots__/index.test.tsx.snap
+++ b/src/common/Footer/__snapshots__/index.test.tsx.snap
@@ -19,6 +19,15 @@ exports[`renders as expected 1`] = `
         >
           Bristlemouth.org
         </a>
+        <a
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-o4qrxl-MuiTypography-root-MuiLink-root"
+          href="https://www.bristlemouth.org/"
+          rel="noopener noreferrer"
+          style="margin-left: 2rem; font-weight: bold; text-align: center;"
+          target="_blank"
+        >
+          Apply for the pioneer program
+        </a>
       </p>
       <div
         class="MuiStack-root css-17fi1qs-MuiStack-root"

--- a/src/common/Footer/index.tsx
+++ b/src/common/Footer/index.tsx
@@ -1,4 +1,11 @@
-import { AppBar, Link, Stack, Typography, styled } from '@mui/material';
+import {
+  AppBar,
+  Link,
+  Stack,
+  Typography,
+  styled,
+  useMediaQuery,
+} from '@mui/material';
 import aqualinkLogo from 'src/assets/aqualink-logo.png';
 import {
   aqualinkURL,
@@ -62,8 +69,9 @@ const BristlemouthLinkTypography = styled(Typography)(({ theme }) => ({
 }));
 
 function Footer() {
+  const isMobile = useMediaQuery('(max-width: 760px)');
   return (
-    <StyledAppBar position="fixed">
+    <StyledAppBar position={isMobile ? 'relative' : 'fixed'}>
       <StackContainer direction="row">
         <BristlemouthLinkTypography>
           <StyledLink
@@ -72,6 +80,18 @@ function Footer() {
             href={bristlemouthURL}
           >
             Bristlemouth.org
+          </StyledLink>
+          <StyledLink
+            target="_blank"
+            rel="noopener noreferrer"
+            href={bristlemouthURL}
+            style={{
+              marginLeft: '2rem',
+              fontWeight: 'bold',
+              textAlign: 'center',
+            }}
+          >
+            Apply for the pioneer program
           </StyledLink>
         </BristlemouthLinkTypography>
 

--- a/src/common/Footer/index.tsx
+++ b/src/common/Footer/index.tsx
@@ -11,6 +11,7 @@ import {
   aqualinkURL,
   bristlemouthURL,
   bristlemouthExplorerGithub,
+  bristlemouthPioneerURL,
 } from 'src/helpers/constants';
 
 const StyledAppBar = styled(AppBar)(({ theme }) => ({
@@ -84,7 +85,7 @@ function Footer() {
           <StyledLink
             target="_blank"
             rel="noopener noreferrer"
-            href={bristlemouthURL}
+            href={bristlemouthPioneerURL}
             style={{
               marginLeft: '2rem',
               fontWeight: 'bold',

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,4 +1,5 @@
 export const bristlemouthURL = 'https://www.bristlemouth.org/';
+export const bristlemouthPioneerURL = 'https://www.bristlemouth.org/pioneer';
 export const aqualinkURL = 'https://aqualink.org';
 export const sofarURL = 'https://www.sofarocean.com';
 export const sofarDocsURL = 'https://docs.sofarocean.com/';

--- a/src/routes/Home/__snapshots__/index.test.tsx.snap
+++ b/src/routes/Home/__snapshots__/index.test.tsx.snap
@@ -28,6 +28,11 @@ exports[`renders as expected 1`] = `
         >
           Bristlemouth Explorer
         </h1>
+        <h3
+          class="MuiTypography-root MuiTypography-h3 css-1coa7he-MuiTypography-root"
+        >
+          Decode data from your Sofar Spotter and Bristlemouth DevKit
+        </h3>
         <div
           class="MuiStack-root css-lgn0cp-MuiStack-root"
         >
@@ -120,6 +125,15 @@ exports[`renders as expected 1`] = `
             target="_blank"
           >
             Bristlemouth.org
+          </a>
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-o4qrxl-MuiTypography-root-MuiLink-root"
+            href="https://www.bristlemouth.org/"
+            rel="noopener noreferrer"
+            style="margin-left: 2rem; font-weight: bold; text-align: center;"
+            target="_blank"
+          >
+            Apply for the pioneer program
           </a>
         </p>
         <div

--- a/src/routes/Home/__snapshots__/index.test.tsx.snap
+++ b/src/routes/Home/__snapshots__/index.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`renders as expected 1`] = `
           </a>
           <a
             class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-o4qrxl-MuiTypography-root-MuiLink-root"
-            href="https://www.bristlemouth.org/"
+            href="https://www.bristlemouth.org/pioneer"
             rel="noopener noreferrer"
             style="margin-left: 2rem; font-weight: bold; text-align: center;"
             target="_blank"

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -76,6 +76,9 @@ function Home() {
         </Link>
         <Stack direction="column" alignItems="center" spacing={5}>
           <TypographyTitle variant="h1">Bristlemouth Explorer</TypographyTitle>
+          <Typography variant="h3" padding="0 2rem" textAlign="center">
+            Decode data from your Sofar Spotter and Bristlemouth DevKit
+          </Typography>
           <Stack direction="column" gap="1rem" spacing={1} width="20rem">
             <Stack>
               <Typography fontWeight="bold">


### PR DESCRIPTION
Fix issue #18 and make the position of the footer relative on mobile to make the landing page more visible.

<img width="1642" alt="Screenshot 2023-12-12 at 3 32 36 PM" src="https://github.com/aqualinkorg/bristlemouth-explorer/assets/16843267/77d3138e-9082-492b-b220-2e240383ef94">

<img width="323" alt="Screenshot 2023-12-12 at 3 30 59 PM" src="https://github.com/aqualinkorg/bristlemouth-explorer/assets/16843267/57a9fd3a-00e9-4190-b7b5-27f4ab606cc4">
